### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 script:
   - java -version
   - ./gradlew -v
-  - travis_wait 60 ./gradlew clean test build check
+  - ./gradlew clean test build check
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
